### PR TITLE
docs: Update README image path to an absolute URL and chore: bump pac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./public/image.png" alt="Snowflake ID Logo" width="600" />
+  <img src="https://raw.githubusercontent.com/maulik-mk/Snowflake-Id/main/public/image.png" alt="Snowflake ID Logo" width="600" />
 </p>
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toolkit-f/snowflake-id",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
This pull request contains minor updates related to documentation and package versioning. The most notable changes are:

Documentation update:
* Updated the image source in `README.md` to use an absolute URL, ensuring the logo displays correctly on external sites.

Package management:
* Bumped the package version in `package.json` from `1.0.0` to `1.0.1` to reflect recent changes.