### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toolkit-f/snowflake-id",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Summary
Bumps package version from `1.0.1` to `1.0.2`.

## Changes
- Updated `version` field in [package.json](cci:7://file:///Users/maulikkadeval/Downloads/editor/Snowflake-Id/package.json:0:0-0:0) from `1.0.1` to `1.0.2`

## Reason
The version bump was missed in the `chore/update-ownership` PR. This PR ensures the package version is updated to reflect the ownership changes.

## Type of Change
- [x] Chore/maintenance